### PR TITLE
Introducing a faster bounded RNG:

### DIFF
--- a/pcg32.go
+++ b/pcg32.go
@@ -50,6 +50,24 @@ func (p *PCG32) Bounded(bound uint32) uint32 {
 	}
 }
 
+// as in int31n, go/src/math/rand/rand.go
+// this function uses a single division in the worst case
+func (p *PCG32) FastBounded(bound uint32) uint32 {
+	v := p.Random()
+	prod := uint64(v) * uint64(bound)
+	low := uint32(prod)
+	if low < uint32(bound) {
+		thresh := uint32(-bound) % uint32(bound)
+		for low < thresh {
+			v = p.Random()
+			prod = uint64(v) * uint64(bound)
+			low = uint32(prod)
+		}
+	}
+	return uint32(prod >> 32)
+}
+
+
 func (p *PCG32) Advance(delta uint64) *PCG32 {
 	p.state = p.advanceLCG64(p.state, delta, pcg32Multiplier, p.increment)
 	return p

--- a/pcg32_test.go
+++ b/pcg32_test.go
@@ -119,6 +119,19 @@ func BenchmarkBounded32(b *testing.B) {
 		// _ = pcg.Bounded(365)           // day of year
 	}
 }
+// Measure the time it takes to generate bounded random values
+func BenchmarkBounded32Fast(b *testing.B) {
+	b.StopTimer()
+	pcg := NewPCG32().Seed(1, 1)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = pcg.FastBounded(uint32(i) & 0xff) // 0..255
+		// _ = pcg.Bounded(6)             // roll of die
+		// _ = pcg.Bounded(52)            // deck of cards
+		// _ = pcg.Bounded(365)           // day of year
+	}
+}
 
 //
 // EXAMPLES


### PR DESCRIPTION
$ go test -bench BenchmarkBounded32
goos: darwin
goarch: amd64
pkg: github.com/lemire/pcg
BenchmarkBounded32-4       	200000000	         7.85 ns/op
BenchmarkBounded32Fast-4   	300000000	         4.79 ns/op
PASS
ok  	github.com/lemire/pcg	4.323s