### PR TITLE
Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/MichaelTJones/pcg
+
+go 1.17


### PR DESCRIPTION
This adds a go.mod file for better support managing dependencies in [Go with modules](https://go.dev/blog/using-go-modules). All of the cool kids started doing this with the preliminary support in Go v1.11 and v1.12, and it became the default with Go 1.13, released in September 2019.  The latest Go version now, in late November 2021, is Go 1.17. 

I mention the dates and versions because the project hasn't had any activity since 2018, before the module support was added. 

Anyway, If you clone the repository and try to run the benchmark with the latest Go 1.17 compiler, you get an error:

```
$ go test -v -bench=.
go: cannot find main module, but found .git/config in ~/src/github.com/mojotx/pcg
	to create a module there, run:
	go mod init
```

